### PR TITLE
fix(api): add timeout to wait_closed() in check_port() to prevent indefinite hang on hard reset

### DIFF
--- a/custom_components/sinapsi_alfa/api.py
+++ b/custom_components/sinapsi_alfa/api.py
@@ -29,6 +29,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    CHECK_PORT_CLOSE_TIMEOUT,
     CUMULATIVE_ENERGY_SENSORS,
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_DEVICE_ID,
@@ -408,11 +409,26 @@ class SinapsiAlfaAPI:
 
             # Clean up the connection
             writer.close()
-            #await writer.wait_closed()
             try:
-                await asyncio.wait_for(writer.wait_closed(), timeout=2.0)
-            except (asyncio.TimeoutError, OSError):
-                pass
+                await asyncio.wait_for(writer.wait_closed(), timeout=CHECK_PORT_CLOSE_TIMEOUT)
+            except TimeoutError:
+                log_debug(
+                    _LOGGER,
+                    "check_port",
+                    "wait_closed timed out — peer did not send FIN, socket abandoned",
+                    host=self._host,
+                    port=self._port,
+                    timeout=CHECK_PORT_CLOSE_TIMEOUT,
+                )
+            except OSError as e:
+                log_debug(
+                    _LOGGER,
+                    "check_port",
+                    "wait_closed raised OSError, ignoring",
+                    host=self._host,
+                    port=self._port,
+                    error=e,
+                )
         except (TimeoutError, ConnectionRefusedError, OSError) as e:
             log_debug(
                 _LOGGER,

--- a/custom_components/sinapsi_alfa/api.py
+++ b/custom_components/sinapsi_alfa/api.py
@@ -408,7 +408,11 @@ class SinapsiAlfaAPI:
 
             # Clean up the connection
             writer.close()
-            await writer.wait_closed()
+            #await writer.wait_closed()
+            try:
+                await asyncio.wait_for(writer.wait_closed(), timeout=2.0)
+            except (asyncio.TimeoutError, OSError):
+                pass
         except (TimeoutError, ConnectionRefusedError, OSError) as e:
             log_debug(
                 _LOGGER,

--- a/custom_components/sinapsi_alfa/const.py
+++ b/custom_components/sinapsi_alfa/const.py
@@ -32,6 +32,11 @@ DEFAULT_TIMEOUT = 10
 MIN_TIMEOUT = 5
 MAX_TIMEOUT = 60
 DEFAULT_CONNECTION_TIMEOUT = 5  # TCP connection establishment (seconds)
+# Timeout (seconds) for writer.wait_closed() in check_port(). After we call
+# writer.close() the peer should send FIN; if the device hard-resets without
+# sending it, wait_closed() would block until the kernel TCP timeout (~10 min).
+# Normal closures complete in milliseconds; only stuck sockets hit this limit.
+CHECK_PORT_CLOSE_TIMEOUT = 2.0
 DEFAULT_SKIP_MAC_DETECTION = False
 MANUFACTURER = "Sinapsi"
 MODEL = "Alfa"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 """Tests for Sinapsi Alfa API."""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -584,6 +585,32 @@ class TestPortCheck:
 
             assert result is False
 
+    async def test_check_port_returns_when_wait_closed_hangs(
+        self, mock_hass, mock_transport, mock_client
+    ):
+        """check_port() must not hang if wait_closed() never returns (issue: hard reset)."""
+        api = SinapsiAlfaAPI(
+            mock_hass, TEST_NAME, TEST_HOST, TEST_PORT,
+            DEFAULT_SCAN_INTERVAL, DEFAULT_TIMEOUT,
+        )
+
+        # Simulate open_connection succeeding then wait_closed() hanging forever.
+        async def hang_forever():
+            await asyncio.sleep(3600)  # never returns within the test
+
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock(side_effect=hang_forever)
+
+        with patch(
+            "custom_components.sinapsi_alfa.api.asyncio.open_connection",
+            AsyncMock(return_value=(MagicMock(), mock_writer)),
+        ):
+            result = await api.check_port()
+
+        # Must return True (port was reachable) and must not have hung.
+        assert result is True
+        mock_writer.close.assert_called_once()
 
 class TestAsyncGetData:
     """Tests for async_get_data method."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -590,8 +590,12 @@ class TestPortCheck:
     ):
         """check_port() must not hang if wait_closed() never returns (issue: hard reset)."""
         api = SinapsiAlfaAPI(
-            mock_hass, TEST_NAME, TEST_HOST, TEST_PORT,
-            DEFAULT_SCAN_INTERVAL, DEFAULT_TIMEOUT,
+            mock_hass,
+            TEST_NAME,
+            TEST_HOST,
+            TEST_PORT,
+            DEFAULT_SCAN_INTERVAL,
+            DEFAULT_TIMEOUT,
         )
 
         # Simulate open_connection succeeding then wait_closed() hanging forever.
@@ -602,15 +606,19 @@ class TestPortCheck:
         mock_writer.close = MagicMock()
         mock_writer.wait_closed = AsyncMock(side_effect=hang_forever)
 
-        with patch(
-            "custom_components.sinapsi_alfa.api.asyncio.open_connection",
-            AsyncMock(return_value=(MagicMock(), mock_writer)),
+        with (
+            patch("custom_components.sinapsi_alfa.api.CHECK_PORT_CLOSE_TIMEOUT", 0.1),
+            patch(
+                "custom_components.sinapsi_alfa.api.asyncio.open_connection",
+                AsyncMock(return_value=(MagicMock(), mock_writer)),
+            ),
         ):
             result = await api.check_port()
 
         # Must return True (port was reachable) and must not have hung.
         assert result is True
         mock_writer.close.assert_called_once()
+
 
 class TestAsyncGetData:
     """Tests for async_get_data method."""


### PR DESCRIPTION
Bug: check_port() calls await writer.wait_closed() with no timeout. When the Alfa device performs a hard reset (watchdog, no TCP FIN sent), the OS keeps the connection in FIN_WAIT state and wait_closed() blocks indefinitely (~10 minutes = OS TCP timeout). While blocked, the DataUpdateCoordinator cannot start new polls, leaving all sensors unavailable.

Root cause: asyncio.StreamWriter.wait_closed() docs warn it may block indefinitely if the remote end does not close the connection.

Evidence: Empirically confirmed — running mbpoll against the device during the hang, causes the Alfa to send RST/FIN, unblocking wait_closed() and immediately restoring sensors.

Fix: Wrap wait_closed() in asyncio.wait_for() with a 2-second timeout. Normal connections close in milliseconds; only stuck connections hit the timeout.

Impact: Hard reset recovery: 10+ min → ~2-3 min (warm-up gate only). No regression risk.