### PR TITLE
fix: keep MEASUREMENT sensors available during device warm-up

### DIFF
--- a/custom_components/sinapsi_alfa/__init__.py
+++ b/custom_components/sinapsi_alfa/__init__.py
@@ -58,11 +58,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: SinapsiAlfaConfig
     # If the refresh fails, async_config_entry_first_refresh() will
     # raise ConfigEntryNotReady and setup will try again later
     # ref.: https://developers.home-assistant.io/docs/integration_setup_failures
-    await coordinator.async_config_entry_first_refresh()
+    # Durante warm-up il dispositivo è raggiungibile ma non ancora pronto:
+    # si procede col setup così le entità vengono registrate subito.
+    # Si solleva ConfigEntryNotReady solo per veri errori di connessione.
+    await coordinator.async_refresh()
+    if not coordinator.last_update_success and not coordinator.last_warmup:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="connection_timeout",
+            translation_placeholders={"device_name": str(config_entry.data.get(CONF_NAME, ""))},
+        )
 
-    # Test to see if api initialised correctly, else raise ConfigNotReady to make HA retry setup
-    # Change this to match how your api will know if connected or successful update
-    if not coordinator.api.data["sn"]:
+    if coordinator.last_update_success and not coordinator.api.data.get("sn"):
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="connection_timeout",

--- a/custom_components/sinapsi_alfa/api.py
+++ b/custom_components/sinapsi_alfa/api.py
@@ -408,7 +408,11 @@ class SinapsiAlfaAPI:
 
             # Clean up the connection
             writer.close()
-            await writer.wait_closed()
+            #await writer.wait_closed()
+            try:
+                await asyncio.wait_for(writer.wait_closed(), timeout=2.0)
+            except (asyncio.TimeoutError, OSError):
+                pass
         except (TimeoutError, ConnectionRefusedError, OSError) as e:
             log_debug(
                 _LOGGER,

--- a/custom_components/sinapsi_alfa/coordinator.py
+++ b/custom_components/sinapsi_alfa/coordinator.py
@@ -71,6 +71,7 @@ class SinapsiAlfaCoordinator(DataUpdateCoordinator[bool]):
         # Migration ensures these exist in options for existing installs
         self.scan_interval = int(config_entry.options[CONF_SCAN_INTERVAL])
         self.timeout = int(config_entry.options[CONF_TIMEOUT])
+        self.last_warmup: bool = False
 
         # enforce scan_interval bounds
         if self.scan_interval < MIN_SCAN_INTERVAL:
@@ -293,6 +294,7 @@ class SinapsiAlfaCoordinator(DataUpdateCoordinator[bool]):
 
             # Reset failure counter on success
             self._consecutive_failures = 0
+            self.last_warmup = False
         except SinapsiWarmupError as ex:
             # Device warm-up after a restart/reboot: registers return 0 for a few
             # minutes. This is an expected transient, not a fault — fail the poll so
@@ -300,6 +302,8 @@ class SinapsiAlfaCoordinator(DataUpdateCoordinator[bool]):
             # the connection-failure counter, the connection issue, or the recovery
             # script. A dedicated warm-up repair issue is raised instead.
             self.last_update_status = False
+            self.last_warmup = True
+            self.async_update_listeners()
             log_info(
                 _LOGGER,
                 "async_update_data",
@@ -310,6 +314,7 @@ class SinapsiAlfaCoordinator(DataUpdateCoordinator[bool]):
             raise UpdateFailed from ex
         except Exception as ex:
             self.last_update_status = False
+            self.last_warmup = False
             self._consecutive_failures += 1
 
             # Determine error type for device trigger

--- a/custom_components/sinapsi_alfa/sensor.py
+++ b/custom_components/sinapsi_alfa/sensor.py
@@ -251,7 +251,9 @@ class SinapsiAlfaSensor(CoordinatorEntity[SinapsiAlfaCoordinator], RestoreSensor
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        if self._is_accumulating_sensor:
+            return self.coordinator.last_update_success
+        return self.coordinator.last_update_success or self._coordinator.last_warmup
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Problem

After each Alfa device watchdog reset (~15 min cycle), all sensors go
unavailable for 4-6 minutes during the post-reset warm-up phase
(fascia=F0, Chain2 not yet synced).

However, `addr 2` (potenza_prelevata) is always valid during warm-up
via PLC broadcast. Only the energy accumulation registers (addr 5-6)
need to wait for Chain2 sync.

## Root Cause

`DataUpdateCoordinator` does not notify listeners on repeated
`UpdateFailed` (failure→failure), so sensors never see fresh
`api.data` even though the device is responding and the data is valid.

## Changes

- **coordinator.py**: add `last_warmup` flag; call
  `async_update_listeners()` in the `SinapsiWarmupError` handler to
  force sensors to read fresh `api.data` on every warm-up poll
- **sensor.py**: split `available` by sensor type — `MEASUREMENT`
  sensors stay available when `last_warmup=True`; `TOTAL_INCREASING`
  sensors remain protected (unavailable during warm-up)
- **__init__.py**: replace `async_config_entry_first_refresh()` with
  `async_refresh()` so a reload during warm-up does not orphan all
  entities in the registry

## Behavior After Fix

| State | MEASUREMENT (kW, V…) | TOTAL_INCREASING (kWh…) |
|---|---|---|
| Normal operation | available ✓ | available ✓ |
| TCP offline | unavailable ✓ | unavailable ✓ |
| Warm-up (fascia=F0) | available, live PLC values ✓ | unavailable (protected) ✓ |
| Reload during warm-up | registered immediately ✓ | registered immediately ✓ |

## Testing

Tested on a real Alfa device over multiple watchdog reset cycles
(~15 min interval, ~4-6 min warm-up).